### PR TITLE
- update README with correct command & output

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ go get -u github.com/go-ego/gpy
 
 ```
 go get -u github.com/go-ego/gpy/tools/pinyin
-$ gpy 中国话
-zhōng guó rén
+$ pinyin 中国话
+zhong guo hua
 ```
 
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -19,8 +19,8 @@ go get -u github.com/go-ego/gpy
 
 ```
 go get -u github.com/go-ego/gpy/tools/pinyin
-$ gpy 中国话
-zhōng guó huà
+$ pinyin 中国话
+zhong guo hua
 ```
 
 


### PR DESCRIPTION
 
## Description

```sh
go get -v -u github.com/go-ego/gpy/tools/pinyin

$ gpy
bash: gpy: command not found
```

I.e.. 

- `gpy` command is not found after doing `go get github.com/go-ego/gpy/tools/pinyin`
- and its current default output do not contain 声调